### PR TITLE
Remove rootDirectory from vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,3 @@
 {
-  "framework": "nextjs",
-  "rootDirectory": "apps/website"
+  "framework": "nextjs"
 }


### PR DESCRIPTION
Remove `rootDirectory` from `vercel.json` because it is an invalid property causing schema validation errors.

The `rootDirectory` property is not a valid part of the `vercel.json` schema. For monorepos, Vercel typically manages the project's root directory through dashboard settings or build configurations, not via this file. Removing it resolves the validation failure.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents?id=bc-2248320b-f0cd-489b-a6d6-ae18d1499254) · [Cursor](https://cursor.com/background-agent?bcId=bc-2248320b-f0cd-489b-a6d6-ae18d1499254)

Refer to [Background Agent docs](https://docs.cursor.com/background-agents)